### PR TITLE
RenderStates UI fix

### DIFF
--- a/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_ImageRender.ui
+++ b/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_ImageRender.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>497</width>
-    <height>937</height>
+    <height>996</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,7 +55,6 @@
        <widget class="QLabel" name="l_class">
         <property name="font">
          <font>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -72,8 +71,76 @@
      <property name="title">
       <string>General</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QWidget" name="w_context" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Context:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>37</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="l_context">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="b_context">
+           <property name="text">
+            <string>Select</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_context"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="f_taskname" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_10">
          <property name="leftMargin">
@@ -127,7 +194,7 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item>
        <widget class="QWidget" name="f_range" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <property name="spacing">
@@ -178,7 +245,7 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item>
        <widget class="QWidget" name="w_frameRangeValues" native="true">
         <layout class="QGridLayout" name="gridLayout">
          <property name="leftMargin">
@@ -287,7 +354,7 @@
         </layout>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item>
        <widget class="QWidget" name="w_frameExpression" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_15">
          <property name="spacing">
@@ -338,7 +405,28 @@
         </layout>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item>
+       <widget class="QWidget" name="f_cam" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="f_resolution" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <property name="spacing">
@@ -446,288 +534,7 @@
         </layout>
        </widget>
       </item>
-      <item row="9" column="0">
-       <widget class="QWidget" name="w_outPath" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_16">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="l_outPath">
-           <property name="text">
-            <string>Location:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_27">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>113</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_outPath">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="10" column="0">
-       <widget class="QWidget" name="f_renderLayer" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Render layer:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_renderLayer">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QWidget" name="w_context" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_11">
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>Context:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>37</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="l_context">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="b_context">
-           <property name="text">
-            <string>Select</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_context"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="13" column="0">
-       <widget class="QWidget" name="f_setOutputOnly" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>If this checkbox is selected, executing the state won't render the node, instead it will set the correct name and version, it will also create the appropiate folders and set the path to it for easy access in the state's UI</string>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_12">
-         <property name="spacing">
-          <number>10</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_9">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Set Output only:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_10">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="chb_outOnly">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QWidget" name="w_master" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_17">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="l_outPath_2">
-           <property name="text">
-            <string>Master Version:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_28">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>113</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_master">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="7" column="0">
+      <item>
        <widget class="QWidget" name="w_renderPreset" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_14">
          <property name="topMargin">
@@ -779,7 +586,211 @@
         </layout>
        </widget>
       </item>
-      <item row="12" column="0">
+      <item>
+       <widget class="QWidget" name="w_master" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="l_outPath_2">
+           <property name="text">
+            <string>Master Version:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_28">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>113</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_master">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="w_outPath" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="l_outPath">
+           <property name="text">
+            <string>Location:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_27">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>113</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_outPath">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="f_renderLayer" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Render layer:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_renderLayer">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="w_format" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Format:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_format">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="f_rendernode" native="true">
         <property name="enabled">
          <bool>true</bool>
@@ -866,32 +877,20 @@
         </layout>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QWidget" name="f_cam" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QWidget" name="f_setOutputOnly" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>If this checkbox is selected, executing the state won't render the node, instead it will set the correct name and version, it will also create the appropiate folders and set the path to it for easy access in the state's UI</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
          <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-        </layout>
-       </widget>
-      </item>
-      <item row="11" column="0">
-       <widget class="QWidget" name="w_format" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <property name="spacing">
-          <number>0</number>
+          <number>10</number>
          </property>
          <property name="leftMargin">
           <number>9</number>
@@ -906,14 +905,17 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_6">
+          <widget class="QLabel" name="label_9">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
            <property name="text">
-            <string>Format:</string>
+            <string>Set Output only:</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_12">
+          <spacer name="horizontalSpacer_10">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -926,12 +928,9 @@
           </spacer>
          </item>
          <item>
-          <widget class="QComboBox" name="cb_format">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
+          <widget class="QCheckBox" name="chb_outOnly">
+           <property name="text">
+            <string/>
            </property>
           </widget>
          </item>

--- a/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_ImageRender_ui.py
+++ b/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_ImageRender_ui.py
@@ -16,7 +16,7 @@ class Ui_wg_ImageRender(object):
     def setupUi(self, wg_ImageRender):
         if not wg_ImageRender.objectName():
             wg_ImageRender.setObjectName(u"wg_ImageRender")
-        wg_ImageRender.resize(497, 937)
+        wg_ImageRender.resize(497, 996)
         self.verticalLayout = QVBoxLayout(wg_ImageRender)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
@@ -48,8 +48,44 @@ class Ui_wg_ImageRender(object):
 
         self.gb_imageRender = QGroupBox(wg_ImageRender)
         self.gb_imageRender.setObjectName(u"gb_imageRender")
-        self.gridLayout_2 = QGridLayout(self.gb_imageRender)
-        self.gridLayout_2.setObjectName(u"gridLayout_2")
+        self.verticalLayout_2 = QVBoxLayout(self.gb_imageRender)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.w_context = QWidget(self.gb_imageRender)
+        self.w_context.setObjectName(u"w_context")
+        self.horizontalLayout_11 = QHBoxLayout(self.w_context)
+        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
+        self.horizontalLayout_11.setContentsMargins(9, 0, 9, 0)
+        self.label_7 = QLabel(self.w_context)
+        self.label_7.setObjectName(u"label_7")
+
+        self.horizontalLayout_11.addWidget(self.label_7)
+
+        self.horizontalSpacer_5 = QSpacerItem(37, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_11.addItem(self.horizontalSpacer_5)
+
+        self.l_context = QLabel(self.w_context)
+        self.l_context.setObjectName(u"l_context")
+
+        self.horizontalLayout_11.addWidget(self.l_context)
+
+        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_11.addItem(self.horizontalSpacer_3)
+
+        self.b_context = QPushButton(self.w_context)
+        self.b_context.setObjectName(u"b_context")
+
+        self.horizontalLayout_11.addWidget(self.b_context)
+
+        self.cb_context = QComboBox(self.w_context)
+        self.cb_context.setObjectName(u"cb_context")
+
+        self.horizontalLayout_11.addWidget(self.cb_context)
+
+
+        self.verticalLayout_2.addWidget(self.w_context)
+
         self.f_taskname = QWidget(self.gb_imageRender)
         self.f_taskname.setObjectName(u"f_taskname")
         self.horizontalLayout_10 = QHBoxLayout(self.f_taskname)
@@ -62,7 +98,7 @@ class Ui_wg_ImageRender(object):
 
         self.l_taskName = QLabel(self.f_taskname)
         self.l_taskName.setObjectName(u"l_taskName")
-        sizePolicy = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.l_taskName.sizePolicy().hasHeightForWidth())
@@ -79,7 +115,7 @@ class Ui_wg_ImageRender(object):
         self.horizontalLayout_10.addWidget(self.b_changeTask)
 
 
-        self.gridLayout_2.addWidget(self.f_taskname, 1, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_taskname)
 
         self.f_range = QWidget(self.gb_imageRender)
         self.f_range.setObjectName(u"f_range")
@@ -92,7 +128,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout.addWidget(self.label_3)
 
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout.addItem(self.horizontalSpacer_2)
 
@@ -103,7 +139,7 @@ class Ui_wg_ImageRender(object):
         self.horizontalLayout.addWidget(self.cb_rangeType)
 
 
-        self.gridLayout_2.addWidget(self.f_range, 2, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_range)
 
         self.w_frameRangeValues = QWidget(self.gb_imageRender)
         self.w_frameRangeValues.setObjectName(u"w_frameRangeValues")
@@ -145,7 +181,7 @@ class Ui_wg_ImageRender(object):
 
         self.gridLayout.addWidget(self.l_rangeStartInfo, 0, 0, 1, 1)
 
-        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.gridLayout.addItem(self.horizontalSpacer_13, 0, 4, 1, 1)
 
@@ -155,7 +191,7 @@ class Ui_wg_ImageRender(object):
         self.gridLayout.addWidget(self.l_rangeEndInfo, 1, 0, 1, 1)
 
 
-        self.gridLayout_2.addWidget(self.w_frameRangeValues, 3, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_frameRangeValues)
 
         self.w_frameExpression = QWidget(self.gb_imageRender)
         self.w_frameExpression.setObjectName(u"w_frameExpression")
@@ -168,7 +204,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_15.addWidget(self.l_frameExpression)
 
-        self.horizontalSpacer_14 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_14 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_15.addItem(self.horizontalSpacer_14)
 
@@ -179,7 +215,16 @@ class Ui_wg_ImageRender(object):
         self.horizontalLayout_15.addWidget(self.le_frameExpression)
 
 
-        self.gridLayout_2.addWidget(self.w_frameExpression, 4, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_frameExpression)
+
+        self.f_cam = QWidget(self.gb_imageRender)
+        self.f_cam.setObjectName(u"f_cam")
+        self.horizontalLayout_2 = QHBoxLayout(self.f_cam)
+        self.horizontalLayout_2.setSpacing(0)
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setContentsMargins(9, 0, 9, 0)
+
+        self.verticalLayout_2.addWidget(self.f_cam)
 
         self.f_resolution = QWidget(self.gb_imageRender)
         self.f_resolution.setObjectName(u"f_resolution")
@@ -193,7 +238,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_9.addWidget(self.label_4)
 
-        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_9.addItem(self.horizontalSpacer_9)
 
@@ -230,140 +275,7 @@ class Ui_wg_ImageRender(object):
         self.horizontalLayout_9.addWidget(self.b_resPresets)
 
 
-        self.gridLayout_2.addWidget(self.f_resolution, 6, 0, 1, 1)
-
-        self.w_outPath = QWidget(self.gb_imageRender)
-        self.w_outPath.setObjectName(u"w_outPath")
-        self.horizontalLayout_16 = QHBoxLayout(self.w_outPath)
-        self.horizontalLayout_16.setSpacing(0)
-        self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
-        self.horizontalLayout_16.setContentsMargins(9, 0, 9, 0)
-        self.l_outPath = QLabel(self.w_outPath)
-        self.l_outPath.setObjectName(u"l_outPath")
-
-        self.horizontalLayout_16.addWidget(self.l_outPath)
-
-        self.horizontalSpacer_27 = QSpacerItem(113, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_16.addItem(self.horizontalSpacer_27)
-
-        self.cb_outPath = QComboBox(self.w_outPath)
-        self.cb_outPath.setObjectName(u"cb_outPath")
-        self.cb_outPath.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_16.addWidget(self.cb_outPath)
-
-
-        self.gridLayout_2.addWidget(self.w_outPath, 9, 0, 1, 1)
-
-        self.f_renderLayer = QWidget(self.gb_imageRender)
-        self.f_renderLayer.setObjectName(u"f_renderLayer")
-        self.horizontalLayout_5 = QHBoxLayout(self.f_renderLayer)
-        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
-        self.horizontalLayout_5.setContentsMargins(9, 0, 9, 0)
-        self.label_5 = QLabel(self.f_renderLayer)
-        self.label_5.setObjectName(u"label_5")
-
-        self.horizontalLayout_5.addWidget(self.label_5)
-
-        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_5.addItem(self.horizontalSpacer_6)
-
-        self.cb_renderLayer = QComboBox(self.f_renderLayer)
-        self.cb_renderLayer.setObjectName(u"cb_renderLayer")
-        self.cb_renderLayer.setEnabled(True)
-        self.cb_renderLayer.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_5.addWidget(self.cb_renderLayer)
-
-
-        self.gridLayout_2.addWidget(self.f_renderLayer, 10, 0, 1, 1)
-
-        self.w_context = QWidget(self.gb_imageRender)
-        self.w_context.setObjectName(u"w_context")
-        self.horizontalLayout_11 = QHBoxLayout(self.w_context)
-        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
-        self.horizontalLayout_11.setContentsMargins(9, 0, 9, 0)
-        self.label_7 = QLabel(self.w_context)
-        self.label_7.setObjectName(u"label_7")
-
-        self.horizontalLayout_11.addWidget(self.label_7)
-
-        self.horizontalSpacer_5 = QSpacerItem(37, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_11.addItem(self.horizontalSpacer_5)
-
-        self.l_context = QLabel(self.w_context)
-        self.l_context.setObjectName(u"l_context")
-
-        self.horizontalLayout_11.addWidget(self.l_context)
-
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_11.addItem(self.horizontalSpacer_3)
-
-        self.b_context = QPushButton(self.w_context)
-        self.b_context.setObjectName(u"b_context")
-
-        self.horizontalLayout_11.addWidget(self.b_context)
-
-        self.cb_context = QComboBox(self.w_context)
-        self.cb_context.setObjectName(u"cb_context")
-
-        self.horizontalLayout_11.addWidget(self.cb_context)
-
-
-        self.gridLayout_2.addWidget(self.w_context, 0, 0, 1, 1)
-
-        self.f_setOutputOnly = QWidget(self.gb_imageRender)
-        self.f_setOutputOnly.setObjectName(u"f_setOutputOnly")
-        self.f_setOutputOnly.setMinimumSize(QSize(0, 0))
-        self.horizontalLayout_12 = QHBoxLayout(self.f_setOutputOnly)
-        self.horizontalLayout_12.setSpacing(10)
-        self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
-        self.horizontalLayout_12.setContentsMargins(9, 0, 9, 0)
-        self.label_9 = QLabel(self.f_setOutputOnly)
-        self.label_9.setObjectName(u"label_9")
-        self.label_9.setEnabled(True)
-
-        self.horizontalLayout_12.addWidget(self.label_9)
-
-        self.horizontalSpacer_10 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_12.addItem(self.horizontalSpacer_10)
-
-        self.chb_outOnly = QCheckBox(self.f_setOutputOnly)
-        self.chb_outOnly.setObjectName(u"chb_outOnly")
-
-        self.horizontalLayout_12.addWidget(self.chb_outOnly)
-
-
-        self.gridLayout_2.addWidget(self.f_setOutputOnly, 13, 0, 1, 1)
-
-        self.w_master = QWidget(self.gb_imageRender)
-        self.w_master.setObjectName(u"w_master")
-        self.horizontalLayout_17 = QHBoxLayout(self.w_master)
-        self.horizontalLayout_17.setSpacing(0)
-        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
-        self.horizontalLayout_17.setContentsMargins(9, 0, 9, 0)
-        self.l_outPath_2 = QLabel(self.w_master)
-        self.l_outPath_2.setObjectName(u"l_outPath_2")
-
-        self.horizontalLayout_17.addWidget(self.l_outPath_2)
-
-        self.horizontalSpacer_28 = QSpacerItem(113, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_17.addItem(self.horizontalSpacer_28)
-
-        self.cb_master = QComboBox(self.w_master)
-        self.cb_master.setObjectName(u"cb_master")
-        self.cb_master.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_17.addWidget(self.cb_master)
-
-
-        self.gridLayout_2.addWidget(self.w_master, 8, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_resolution)
 
         self.w_renderPreset = QWidget(self.gb_imageRender)
         self.w_renderPreset.setObjectName(u"w_renderPreset")
@@ -375,7 +287,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_14.addWidget(self.l_renderPreset)
 
-        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_14.addItem(self.horizontalSpacer_7)
 
@@ -392,12 +304,108 @@ class Ui_wg_ImageRender(object):
         self.horizontalLayout_14.addWidget(self.cb_renderPreset)
 
 
-        self.gridLayout_2.addWidget(self.w_renderPreset, 7, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_renderPreset)
+
+        self.w_master = QWidget(self.gb_imageRender)
+        self.w_master.setObjectName(u"w_master")
+        self.horizontalLayout_17 = QHBoxLayout(self.w_master)
+        self.horizontalLayout_17.setSpacing(0)
+        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
+        self.horizontalLayout_17.setContentsMargins(9, 0, 9, 0)
+        self.l_outPath_2 = QLabel(self.w_master)
+        self.l_outPath_2.setObjectName(u"l_outPath_2")
+
+        self.horizontalLayout_17.addWidget(self.l_outPath_2)
+
+        self.horizontalSpacer_28 = QSpacerItem(113, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_17.addItem(self.horizontalSpacer_28)
+
+        self.cb_master = QComboBox(self.w_master)
+        self.cb_master.setObjectName(u"cb_master")
+        self.cb_master.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_17.addWidget(self.cb_master)
+
+
+        self.verticalLayout_2.addWidget(self.w_master)
+
+        self.w_outPath = QWidget(self.gb_imageRender)
+        self.w_outPath.setObjectName(u"w_outPath")
+        self.horizontalLayout_16 = QHBoxLayout(self.w_outPath)
+        self.horizontalLayout_16.setSpacing(0)
+        self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
+        self.horizontalLayout_16.setContentsMargins(9, 0, 9, 0)
+        self.l_outPath = QLabel(self.w_outPath)
+        self.l_outPath.setObjectName(u"l_outPath")
+
+        self.horizontalLayout_16.addWidget(self.l_outPath)
+
+        self.horizontalSpacer_27 = QSpacerItem(113, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_16.addItem(self.horizontalSpacer_27)
+
+        self.cb_outPath = QComboBox(self.w_outPath)
+        self.cb_outPath.setObjectName(u"cb_outPath")
+        self.cb_outPath.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_16.addWidget(self.cb_outPath)
+
+
+        self.verticalLayout_2.addWidget(self.w_outPath)
+
+        self.f_renderLayer = QWidget(self.gb_imageRender)
+        self.f_renderLayer.setObjectName(u"f_renderLayer")
+        self.horizontalLayout_5 = QHBoxLayout(self.f_renderLayer)
+        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
+        self.horizontalLayout_5.setContentsMargins(9, 0, 9, 0)
+        self.label_5 = QLabel(self.f_renderLayer)
+        self.label_5.setObjectName(u"label_5")
+
+        self.horizontalLayout_5.addWidget(self.label_5)
+
+        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_5.addItem(self.horizontalSpacer_6)
+
+        self.cb_renderLayer = QComboBox(self.f_renderLayer)
+        self.cb_renderLayer.setObjectName(u"cb_renderLayer")
+        self.cb_renderLayer.setEnabled(True)
+        self.cb_renderLayer.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_5.addWidget(self.cb_renderLayer)
+
+
+        self.verticalLayout_2.addWidget(self.f_renderLayer)
+
+        self.w_format = QWidget(self.gb_imageRender)
+        self.w_format.setObjectName(u"w_format")
+        self.horizontalLayout_6 = QHBoxLayout(self.w_format)
+        self.horizontalLayout_6.setSpacing(0)
+        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
+        self.horizontalLayout_6.setContentsMargins(9, 0, 9, 0)
+        self.label_6 = QLabel(self.w_format)
+        self.label_6.setObjectName(u"label_6")
+
+        self.horizontalLayout_6.addWidget(self.label_6)
+
+        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_6.addItem(self.horizontalSpacer_12)
+
+        self.cb_format = QComboBox(self.w_format)
+        self.cb_format.setObjectName(u"cb_format")
+        self.cb_format.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_6.addWidget(self.cb_format)
+
+
+        self.verticalLayout_2.addWidget(self.w_format)
 
         self.f_rendernode = QWidget(self.gb_imageRender)
         self.f_rendernode.setObjectName(u"f_rendernode")
         self.f_rendernode.setEnabled(True)
-        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.f_rendernode.sizePolicy().hasHeightForWidth())
@@ -414,14 +422,14 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_20.addWidget(self.label_10)
 
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_20.addItem(self.horizontalSpacer)
 
         self.b_setRendernode = QPushButton(self.f_rendernode)
         self.b_setRendernode.setObjectName(u"b_setRendernode")
         self.b_setRendernode.setEnabled(True)
-        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
         sizePolicy2.setHeightForWidth(self.b_setRendernode.sizePolicy().hasHeightForWidth())
@@ -431,40 +439,32 @@ class Ui_wg_ImageRender(object):
         self.horizontalLayout_20.addWidget(self.b_setRendernode)
 
 
-        self.gridLayout_2.addWidget(self.f_rendernode, 12, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_rendernode)
 
-        self.f_cam = QWidget(self.gb_imageRender)
-        self.f_cam.setObjectName(u"f_cam")
-        self.horizontalLayout_2 = QHBoxLayout(self.f_cam)
-        self.horizontalLayout_2.setSpacing(0)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.horizontalLayout_2.setContentsMargins(9, 0, 9, 0)
+        self.f_setOutputOnly = QWidget(self.gb_imageRender)
+        self.f_setOutputOnly.setObjectName(u"f_setOutputOnly")
+        self.f_setOutputOnly.setMinimumSize(QSize(0, 0))
+        self.horizontalLayout_12 = QHBoxLayout(self.f_setOutputOnly)
+        self.horizontalLayout_12.setSpacing(10)
+        self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
+        self.horizontalLayout_12.setContentsMargins(9, 0, 9, 0)
+        self.label_9 = QLabel(self.f_setOutputOnly)
+        self.label_9.setObjectName(u"label_9")
+        self.label_9.setEnabled(True)
 
-        self.gridLayout_2.addWidget(self.f_cam, 5, 0, 1, 1)
+        self.horizontalLayout_12.addWidget(self.label_9)
 
-        self.w_format = QWidget(self.gb_imageRender)
-        self.w_format.setObjectName(u"w_format")
-        self.horizontalLayout_6 = QHBoxLayout(self.w_format)
-        self.horizontalLayout_6.setSpacing(0)
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
-        self.horizontalLayout_6.setContentsMargins(9, 0, 9, 0)
-        self.label_6 = QLabel(self.w_format)
-        self.label_6.setObjectName(u"label_6")
+        self.horizontalSpacer_10 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_6.addWidget(self.label_6)
+        self.horizontalLayout_12.addItem(self.horizontalSpacer_10)
 
-        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.chb_outOnly = QCheckBox(self.f_setOutputOnly)
+        self.chb_outOnly.setObjectName(u"chb_outOnly")
 
-        self.horizontalLayout_6.addItem(self.horizontalSpacer_12)
-
-        self.cb_format = QComboBox(self.w_format)
-        self.cb_format.setObjectName(u"cb_format")
-        self.cb_format.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_6.addWidget(self.cb_format)
+        self.horizontalLayout_12.addWidget(self.chb_outOnly)
 
 
-        self.gridLayout_2.addWidget(self.w_format, 11, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_setOutputOnly)
 
 
         self.verticalLayout.addWidget(self.gb_imageRender)
@@ -486,7 +486,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_13.addWidget(self.l_manager)
 
-        self.horizontalSpacer_19 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_19 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_13.addItem(self.horizontalSpacer_19)
 
@@ -509,7 +509,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_21.addWidget(self.l_rjPrio)
 
-        self.horizontalSpacer_16 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_16 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_21.addItem(self.horizontalSpacer_16)
 
@@ -533,7 +533,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_22.addWidget(self.label_15)
 
-        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_22.addItem(self.horizontalSpacer_17)
 
@@ -557,7 +557,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_28.addWidget(self.l_rjTimeout)
 
-        self.horizontalSpacer_23 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_23 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_28.addItem(self.horizontalSpacer_23)
 
@@ -582,7 +582,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_26.addWidget(self.label_18)
 
-        self.horizontalSpacer_20 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_20 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_26.addItem(self.horizontalSpacer_20)
 
@@ -605,7 +605,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_27.addWidget(self.label_19)
 
-        self.horizontalSpacer_22 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_22 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_27.addItem(self.horizontalSpacer_22)
 
@@ -628,7 +628,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_23.addWidget(self.label_16)
 
-        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_23.addItem(self.horizontalSpacer_18)
 
@@ -651,7 +651,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_24.addWidget(self.label_17)
 
-        self.horizontalSpacer_21 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_21 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_24.addItem(self.horizontalSpacer_21)
 
@@ -694,7 +694,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_29.addWidget(self.l_dlConcurrentTasks)
 
-        self.horizontalSpacer_24 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_24 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_29.addItem(self.horizontalSpacer_24)
 
@@ -719,7 +719,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_30.addWidget(self.l_dlGPUpt)
 
-        self.horizontalSpacer_25 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_25 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_30.addItem(self.horizontalSpacer_25)
 
@@ -744,7 +744,7 @@ class Ui_wg_ImageRender(object):
 
         self.horizontalLayout_31.addWidget(self.l_dlGPUdevices)
 
-        self.horizontalSpacer_26 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_26 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_31.addItem(self.horizontalSpacer_26)
 
@@ -822,6 +822,9 @@ class Ui_wg_ImageRender(object):
         self.l_name.setText(QCoreApplication.translate("wg_ImageRender", u"Name:", None))
         self.l_class.setText(QCoreApplication.translate("wg_ImageRender", u"ImageRender", None))
         self.gb_imageRender.setTitle(QCoreApplication.translate("wg_ImageRender", u"General", None))
+        self.label_7.setText(QCoreApplication.translate("wg_ImageRender", u"Context:", None))
+        self.l_context.setText("")
+        self.b_context.setText(QCoreApplication.translate("wg_ImageRender", u"Select", None))
         self.label_2.setText(QCoreApplication.translate("wg_ImageRender", u"Identifier:", None))
         self.l_taskName.setText("")
         self.b_changeTask.setText(QCoreApplication.translate("wg_ImageRender", u"change", None))
@@ -834,25 +837,22 @@ class Ui_wg_ImageRender(object):
         self.label_4.setText(QCoreApplication.translate("wg_ImageRender", u"Resolution override:", None))
         self.chb_resOverride.setText("")
         self.b_resPresets.setText(QCoreApplication.translate("wg_ImageRender", u"\u25bc", None))
-        self.l_outPath.setText(QCoreApplication.translate("wg_ImageRender", u"Location:", None))
-        self.label_5.setText(QCoreApplication.translate("wg_ImageRender", u"Render layer:", None))
-        self.label_7.setText(QCoreApplication.translate("wg_ImageRender", u"Context:", None))
-        self.l_context.setText("")
-        self.b_context.setText(QCoreApplication.translate("wg_ImageRender", u"Select", None))
-#if QT_CONFIG(tooltip)
-        self.f_setOutputOnly.setToolTip(QCoreApplication.translate("wg_ImageRender", u"If this checkbox is selected, executing the state won't render the node, instead it will set the correct name and version, it will also create the appropiate folders and set the path to it for easy access in the state's UI", None))
-#endif // QT_CONFIG(tooltip)
-        self.label_9.setText(QCoreApplication.translate("wg_ImageRender", u"Set Output only:", None))
-        self.chb_outOnly.setText("")
-        self.l_outPath_2.setText(QCoreApplication.translate("wg_ImageRender", u"Master Version:", None))
         self.l_renderPreset.setText(QCoreApplication.translate("wg_ImageRender", u"Rendersettings preset:", None))
         self.chb_renderPreset.setText("")
+        self.l_outPath_2.setText(QCoreApplication.translate("wg_ImageRender", u"Master Version:", None))
+        self.l_outPath.setText(QCoreApplication.translate("wg_ImageRender", u"Location:", None))
+        self.label_5.setText(QCoreApplication.translate("wg_ImageRender", u"Render layer:", None))
+        self.label_6.setText(QCoreApplication.translate("wg_ImageRender", u"Format:", None))
         self.label_10.setText(QCoreApplication.translate("wg_ImageRender", u"RenderNode:", None))
 #if QT_CONFIG(tooltip)
         self.b_setRendernode.setToolTip(QCoreApplication.translate("wg_ImageRender", u"Set RenderNode by name or create a new one", None))
 #endif // QT_CONFIG(tooltip)
         self.b_setRendernode.setText(QCoreApplication.translate("wg_ImageRender", u"SetRenderNode", None))
-        self.label_6.setText(QCoreApplication.translate("wg_ImageRender", u"Format:", None))
+#if QT_CONFIG(tooltip)
+        self.f_setOutputOnly.setToolTip(QCoreApplication.translate("wg_ImageRender", u"If this checkbox is selected, executing the state won't render the node, instead it will set the correct name and version, it will also create the appropiate folders and set the path to it for easy access in the state's UI", None))
+#endif // QT_CONFIG(tooltip)
+        self.label_9.setText(QCoreApplication.translate("wg_ImageRender", u"Set Output only:", None))
+        self.chb_outOnly.setText("")
         self.gb_submit.setTitle(QCoreApplication.translate("wg_ImageRender", u"Submit Render Job", None))
         self.l_manager.setText(QCoreApplication.translate("wg_ImageRender", u"Manager:", None))
         self.l_rjPrio.setText(QCoreApplication.translate("wg_ImageRender", u"Priority:", None))

--- a/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_NetRender.ui
+++ b/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_NetRender.ui
@@ -55,7 +55,6 @@
        <widget class="QLabel" name="l_class">
         <property name="font">
          <font>
-          <weight>75</weight>
           <bold>true</bold>
          </font>
         </property>
@@ -72,86 +71,51 @@
      <property name="title">
       <string>General</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="6" column="0">
-       <widget class="QWidget" name="w_renderPreset" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_14">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QWidget" name="w_context" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
          <property name="topMargin">
           <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
          </property>
          <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="l_renderPreset">
+          <widget class="QLabel" name="label_7">
            <property name="text">
-            <string>Rendersettings preset:</string>
+            <string>Context:</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_7">
+          <spacer name="horizontalSpacer_5">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>37</width>
              <height>20</height>
             </size>
            </property>
           </spacer>
          </item>
          <item>
-          <widget class="QCheckBox" name="chb_renderPreset">
+          <widget class="QLabel" name="l_context">
            <property name="text">
             <string/>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="cb_renderPreset">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="10" column="0">
-       <widget class="QWidget" name="w_format" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>Format:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_12">
+          <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -164,24 +128,21 @@
           </spacer>
          </item>
          <item>
-          <widget class="QComboBox" name="cb_format">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
+          <widget class="QPushButton" name="b_context">
+           <property name="text">
+            <string>Select</string>
            </property>
           </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_context"/>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="7" column="0">
-       <widget class="QWidget" name="w_master" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_17">
-         <property name="spacing">
-          <number>0</number>
-         </property>
+      <item>
+       <widget class="QWidget" name="f_taskname" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_10">
          <property name="leftMargin">
           <number>9</number>
          </property>
@@ -195,92 +156,47 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="l_outPath_2">
+          <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>Master Version:</string>
+            <string>Identifier:</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_28">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+          <widget class="QLabel" name="l_taskName">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>113</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_master">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="9" column="0">
-       <widget class="QWidget" name="f_renderLayer" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_5">
            <property name="text">
-            <string>Render layer:</string>
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_renderLayer">
+          <widget class="QPushButton" name="b_changeTask">
            <property name="enabled">
             <bool>true</bool>
            </property>
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="text">
+            <string>change</string>
            </property>
           </widget>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="8" column="0">
-       <widget class="QWidget" name="w_outPath" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_16">
+      <item>
+       <widget class="QWidget" name="f_range" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -297,65 +213,14 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="l_outPath">
+          <widget class="QLabel" name="label_3">
            <property name="text">
-            <string>Location:</string>
+            <string>Framerange:</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_27">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>113</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_outPath">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QWidget" name="w_frameExpression" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_15">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="l_frameExpression">
-           <property name="text">
-            <string>Frame expression:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_14">
+          <spacer name="horizontalSpacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -368,7 +233,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QLineEdit" name="le_frameExpression">
+          <widget class="QComboBox" name="cb_rangeType">
            <property name="minimumSize">
             <size>
              <width>150</width>
@@ -380,28 +245,7 @@
         </layout>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QWidget" name="f_cam" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-        </layout>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item>
        <widget class="QWidget" name="w_frameRangeValues" native="true">
         <layout class="QGridLayout" name="gridLayout">
          <property name="leftMargin">
@@ -510,9 +354,133 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QWidget" name="f_range" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QWidget" name="w_frameExpression" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="l_frameExpression">
+           <property name="text">
+            <string>Frame expression:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_14">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="le_frameExpression">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="f_cam" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="w_renderPreset" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_14">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="l_renderPreset">
+           <property name="text">
+            <string>Rendersettings preset:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="chb_renderPreset">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_renderPreset">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="w_master" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -529,27 +497,27 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="l_outPath_2">
            <property name="text">
-            <string>Framerange:</string>
+            <string>Master Version:</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_2">
+          <spacer name="horizontalSpacer_28">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>113</width>
              <height>20</height>
             </size>
            </property>
           </spacer>
          </item>
          <item>
-          <widget class="QComboBox" name="cb_rangeType">
+          <widget class="QComboBox" name="cb_master">
            <property name="minimumSize">
             <size>
              <width>150</width>
@@ -561,9 +529,12 @@
         </layout>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QWidget" name="f_taskname" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_10">
+      <item>
+       <widget class="QWidget" name="w_outPath" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <property name="spacing">
+          <number>0</number>
+         </property>
          <property name="leftMargin">
           <number>9</number>
          </property>
@@ -577,88 +548,62 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="l_outPath">
            <property name="text">
-            <string>Identifier:</string>
+            <string>Location:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="l_taskName">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="b_changeTask">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="text">
-            <string>change</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QWidget" name="w_context" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_11">
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>Context:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
+          <spacer name="horizontalSpacer_27">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>37</width>
+             <width>113</width>
              <height>20</height>
             </size>
            </property>
           </spacer>
          </item>
          <item>
-          <widget class="QLabel" name="l_context">
+          <widget class="QComboBox" name="cb_outPath">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="f_renderLayer" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_5">
            <property name="text">
-            <string/>
+            <string>Render layer:</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_3">
+          <spacer name="horizontalSpacer_6">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -671,19 +616,73 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="b_context">
-           <property name="text">
-            <string>Select</string>
+          <widget class="QComboBox" name="cb_renderLayer">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
            </property>
           </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="cb_context"/>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="11" column="0">
+      <item>
+       <widget class="QWidget" name="w_format" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>9</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>9</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Format:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cb_format">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="f_updateVersion" native="true">
         <property name="toolTip">
          <string>If this checkbox is selected, executing the state won't render the node, instead it will set the correct name and version, it will also create the appropiate folders and set the path to it for easy access in the state's UI</string>
@@ -1364,7 +1363,7 @@
            <x>0</x>
            <y>0</y>
            <width>446</width>
-           <height>144</height>
+           <height>95</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_NetRender_ui.py
+++ b/Fusion/Scripts/StateManagerNodes/StateUserInterfaces/fus_NetRender_ui.py
@@ -48,165 +48,98 @@ class Ui_wg_NetRender(object):
 
         self.gb_NetRender = QGroupBox(wg_NetRender)
         self.gb_NetRender.setObjectName(u"gb_NetRender")
-        self.gridLayout_2 = QGridLayout(self.gb_NetRender)
-        self.gridLayout_2.setObjectName(u"gridLayout_2")
-        self.w_renderPreset = QWidget(self.gb_NetRender)
-        self.w_renderPreset.setObjectName(u"w_renderPreset")
-        self.horizontalLayout_14 = QHBoxLayout(self.w_renderPreset)
-        self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
-        self.horizontalLayout_14.setContentsMargins(-1, 0, -1, 0)
-        self.l_renderPreset = QLabel(self.w_renderPreset)
-        self.l_renderPreset.setObjectName(u"l_renderPreset")
+        self.verticalLayout_2 = QVBoxLayout(self.gb_NetRender)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.w_context = QWidget(self.gb_NetRender)
+        self.w_context.setObjectName(u"w_context")
+        self.horizontalLayout_11 = QHBoxLayout(self.w_context)
+        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
+        self.horizontalLayout_11.setContentsMargins(9, 0, 9, 0)
+        self.label_7 = QLabel(self.w_context)
+        self.label_7.setObjectName(u"label_7")
 
-        self.horizontalLayout_14.addWidget(self.l_renderPreset)
+        self.horizontalLayout_11.addWidget(self.label_7)
 
-        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_5 = QSpacerItem(37, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_14.addItem(self.horizontalSpacer_7)
+        self.horizontalLayout_11.addItem(self.horizontalSpacer_5)
 
-        self.chb_renderPreset = QCheckBox(self.w_renderPreset)
-        self.chb_renderPreset.setObjectName(u"chb_renderPreset")
+        self.l_context = QLabel(self.w_context)
+        self.l_context.setObjectName(u"l_context")
 
-        self.horizontalLayout_14.addWidget(self.chb_renderPreset)
+        self.horizontalLayout_11.addWidget(self.l_context)
 
-        self.cb_renderPreset = QComboBox(self.w_renderPreset)
-        self.cb_renderPreset.setObjectName(u"cb_renderPreset")
-        self.cb_renderPreset.setEnabled(False)
-        self.cb_renderPreset.setMinimumSize(QSize(150, 0))
+        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_14.addWidget(self.cb_renderPreset)
+        self.horizontalLayout_11.addItem(self.horizontalSpacer_3)
 
+        self.b_context = QPushButton(self.w_context)
+        self.b_context.setObjectName(u"b_context")
 
-        self.gridLayout_2.addWidget(self.w_renderPreset, 6, 0, 1, 1)
+        self.horizontalLayout_11.addWidget(self.b_context)
 
-        self.w_format = QWidget(self.gb_NetRender)
-        self.w_format.setObjectName(u"w_format")
-        self.horizontalLayout_6 = QHBoxLayout(self.w_format)
-        self.horizontalLayout_6.setSpacing(0)
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
-        self.horizontalLayout_6.setContentsMargins(9, 0, 9, 0)
-        self.label_6 = QLabel(self.w_format)
-        self.label_6.setObjectName(u"label_6")
+        self.cb_context = QComboBox(self.w_context)
+        self.cb_context.setObjectName(u"cb_context")
 
-        self.horizontalLayout_6.addWidget(self.label_6)
-
-        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_6.addItem(self.horizontalSpacer_12)
-
-        self.cb_format = QComboBox(self.w_format)
-        self.cb_format.setObjectName(u"cb_format")
-        self.cb_format.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_6.addWidget(self.cb_format)
+        self.horizontalLayout_11.addWidget(self.cb_context)
 
 
-        self.gridLayout_2.addWidget(self.w_format, 10, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_context)
 
-        self.w_master = QWidget(self.gb_NetRender)
-        self.w_master.setObjectName(u"w_master")
-        self.horizontalLayout_17 = QHBoxLayout(self.w_master)
-        self.horizontalLayout_17.setSpacing(0)
-        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
-        self.horizontalLayout_17.setContentsMargins(9, 0, 9, 0)
-        self.l_outPath_2 = QLabel(self.w_master)
-        self.l_outPath_2.setObjectName(u"l_outPath_2")
+        self.f_taskname = QWidget(self.gb_NetRender)
+        self.f_taskname.setObjectName(u"f_taskname")
+        self.horizontalLayout_10 = QHBoxLayout(self.f_taskname)
+        self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
+        self.horizontalLayout_10.setContentsMargins(9, 0, 9, 0)
+        self.label_2 = QLabel(self.f_taskname)
+        self.label_2.setObjectName(u"label_2")
 
-        self.horizontalLayout_17.addWidget(self.l_outPath_2)
+        self.horizontalLayout_10.addWidget(self.label_2)
 
-        self.horizontalSpacer_28 = QSpacerItem(113, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.l_taskName = QLabel(self.f_taskname)
+        self.l_taskName.setObjectName(u"l_taskName")
+        sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.l_taskName.sizePolicy().hasHeightForWidth())
+        self.l_taskName.setSizePolicy(sizePolicy)
+        self.l_taskName.setAlignment(Qt.AlignCenter)
 
-        self.horizontalLayout_17.addItem(self.horizontalSpacer_28)
+        self.horizontalLayout_10.addWidget(self.l_taskName)
 
-        self.cb_master = QComboBox(self.w_master)
-        self.cb_master.setObjectName(u"cb_master")
-        self.cb_master.setMinimumSize(QSize(150, 0))
+        self.b_changeTask = QPushButton(self.f_taskname)
+        self.b_changeTask.setObjectName(u"b_changeTask")
+        self.b_changeTask.setEnabled(True)
+        self.b_changeTask.setFocusPolicy(Qt.NoFocus)
 
-        self.horizontalLayout_17.addWidget(self.cb_master)
-
-
-        self.gridLayout_2.addWidget(self.w_master, 7, 0, 1, 1)
-
-        self.f_renderLayer = QWidget(self.gb_NetRender)
-        self.f_renderLayer.setObjectName(u"f_renderLayer")
-        self.horizontalLayout_5 = QHBoxLayout(self.f_renderLayer)
-        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
-        self.horizontalLayout_5.setContentsMargins(9, 0, 9, 0)
-        self.label_5 = QLabel(self.f_renderLayer)
-        self.label_5.setObjectName(u"label_5")
-
-        self.horizontalLayout_5.addWidget(self.label_5)
-
-        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_5.addItem(self.horizontalSpacer_6)
-
-        self.cb_renderLayer = QComboBox(self.f_renderLayer)
-        self.cb_renderLayer.setObjectName(u"cb_renderLayer")
-        self.cb_renderLayer.setEnabled(True)
-        self.cb_renderLayer.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_5.addWidget(self.cb_renderLayer)
+        self.horizontalLayout_10.addWidget(self.b_changeTask)
 
 
-        self.gridLayout_2.addWidget(self.f_renderLayer, 9, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_taskname)
 
-        self.w_outPath = QWidget(self.gb_NetRender)
-        self.w_outPath.setObjectName(u"w_outPath")
-        self.horizontalLayout_16 = QHBoxLayout(self.w_outPath)
-        self.horizontalLayout_16.setSpacing(0)
-        self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
-        self.horizontalLayout_16.setContentsMargins(9, 0, 9, 0)
-        self.l_outPath = QLabel(self.w_outPath)
-        self.l_outPath.setObjectName(u"l_outPath")
+        self.f_range = QWidget(self.gb_NetRender)
+        self.f_range.setObjectName(u"f_range")
+        self.horizontalLayout = QHBoxLayout(self.f_range)
+        self.horizontalLayout.setSpacing(0)
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setContentsMargins(9, 0, 9, 0)
+        self.label_3 = QLabel(self.f_range)
+        self.label_3.setObjectName(u"label_3")
 
-        self.horizontalLayout_16.addWidget(self.l_outPath)
+        self.horizontalLayout.addWidget(self.label_3)
 
-        self.horizontalSpacer_27 = QSpacerItem(113, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_16.addItem(self.horizontalSpacer_27)
+        self.horizontalLayout.addItem(self.horizontalSpacer_2)
 
-        self.cb_outPath = QComboBox(self.w_outPath)
-        self.cb_outPath.setObjectName(u"cb_outPath")
-        self.cb_outPath.setMinimumSize(QSize(150, 0))
+        self.cb_rangeType = QComboBox(self.f_range)
+        self.cb_rangeType.setObjectName(u"cb_rangeType")
+        self.cb_rangeType.setMinimumSize(QSize(150, 0))
 
-        self.horizontalLayout_16.addWidget(self.cb_outPath)
-
-
-        self.gridLayout_2.addWidget(self.w_outPath, 8, 0, 1, 1)
-
-        self.w_frameExpression = QWidget(self.gb_NetRender)
-        self.w_frameExpression.setObjectName(u"w_frameExpression")
-        self.horizontalLayout_15 = QHBoxLayout(self.w_frameExpression)
-        self.horizontalLayout_15.setSpacing(6)
-        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
-        self.horizontalLayout_15.setContentsMargins(9, 0, 9, 0)
-        self.l_frameExpression = QLabel(self.w_frameExpression)
-        self.l_frameExpression.setObjectName(u"l_frameExpression")
-
-        self.horizontalLayout_15.addWidget(self.l_frameExpression)
-
-        self.horizontalSpacer_14 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.horizontalLayout_15.addItem(self.horizontalSpacer_14)
-
-        self.le_frameExpression = QLineEdit(self.w_frameExpression)
-        self.le_frameExpression.setObjectName(u"le_frameExpression")
-        self.le_frameExpression.setMinimumSize(QSize(150, 0))
-
-        self.horizontalLayout_15.addWidget(self.le_frameExpression)
+        self.horizontalLayout.addWidget(self.cb_rangeType)
 
 
-        self.gridLayout_2.addWidget(self.w_frameExpression, 4, 0, 1, 1)
-
-        self.f_cam = QWidget(self.gb_NetRender)
-        self.f_cam.setObjectName(u"f_cam")
-        self.horizontalLayout_2 = QHBoxLayout(self.f_cam)
-        self.horizontalLayout_2.setSpacing(0)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.horizontalLayout_2.setContentsMargins(9, 0, 9, 0)
-
-        self.gridLayout_2.addWidget(self.f_cam, 5, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_range)
 
         self.w_frameRangeValues = QWidget(self.gb_NetRender)
         self.w_frameRangeValues.setObjectName(u"w_frameRangeValues")
@@ -248,7 +181,7 @@ class Ui_wg_NetRender(object):
 
         self.gridLayout.addWidget(self.l_rangeStartInfo, 0, 0, 1, 1)
 
-        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.gridLayout.addItem(self.horizontalSpacer_13, 0, 4, 1, 1)
 
@@ -258,98 +191,165 @@ class Ui_wg_NetRender(object):
         self.gridLayout.addWidget(self.l_rangeEndInfo, 1, 0, 1, 1)
 
 
-        self.gridLayout_2.addWidget(self.w_frameRangeValues, 3, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_frameRangeValues)
 
-        self.f_range = QWidget(self.gb_NetRender)
-        self.f_range.setObjectName(u"f_range")
-        self.horizontalLayout = QHBoxLayout(self.f_range)
-        self.horizontalLayout.setSpacing(0)
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.horizontalLayout.setContentsMargins(9, 0, 9, 0)
-        self.label_3 = QLabel(self.f_range)
-        self.label_3.setObjectName(u"label_3")
+        self.w_frameExpression = QWidget(self.gb_NetRender)
+        self.w_frameExpression.setObjectName(u"w_frameExpression")
+        self.horizontalLayout_15 = QHBoxLayout(self.w_frameExpression)
+        self.horizontalLayout_15.setSpacing(6)
+        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
+        self.horizontalLayout_15.setContentsMargins(9, 0, 9, 0)
+        self.l_frameExpression = QLabel(self.w_frameExpression)
+        self.l_frameExpression.setObjectName(u"l_frameExpression")
 
-        self.horizontalLayout.addWidget(self.label_3)
+        self.horizontalLayout_15.addWidget(self.l_frameExpression)
 
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_14 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout.addItem(self.horizontalSpacer_2)
+        self.horizontalLayout_15.addItem(self.horizontalSpacer_14)
 
-        self.cb_rangeType = QComboBox(self.f_range)
-        self.cb_rangeType.setObjectName(u"cb_rangeType")
-        self.cb_rangeType.setMinimumSize(QSize(150, 0))
+        self.le_frameExpression = QLineEdit(self.w_frameExpression)
+        self.le_frameExpression.setObjectName(u"le_frameExpression")
+        self.le_frameExpression.setMinimumSize(QSize(150, 0))
 
-        self.horizontalLayout.addWidget(self.cb_rangeType)
-
-
-        self.gridLayout_2.addWidget(self.f_range, 2, 0, 1, 1)
-
-        self.f_taskname = QWidget(self.gb_NetRender)
-        self.f_taskname.setObjectName(u"f_taskname")
-        self.horizontalLayout_10 = QHBoxLayout(self.f_taskname)
-        self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
-        self.horizontalLayout_10.setContentsMargins(9, 0, 9, 0)
-        self.label_2 = QLabel(self.f_taskname)
-        self.label_2.setObjectName(u"label_2")
-
-        self.horizontalLayout_10.addWidget(self.label_2)
-
-        self.l_taskName = QLabel(self.f_taskname)
-        self.l_taskName.setObjectName(u"l_taskName")
-        sizePolicy = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
-        sizePolicy.setHorizontalStretch(0)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.l_taskName.sizePolicy().hasHeightForWidth())
-        self.l_taskName.setSizePolicy(sizePolicy)
-        self.l_taskName.setAlignment(Qt.AlignCenter)
-
-        self.horizontalLayout_10.addWidget(self.l_taskName)
-
-        self.b_changeTask = QPushButton(self.f_taskname)
-        self.b_changeTask.setObjectName(u"b_changeTask")
-        self.b_changeTask.setEnabled(True)
-        self.b_changeTask.setFocusPolicy(Qt.NoFocus)
-
-        self.horizontalLayout_10.addWidget(self.b_changeTask)
+        self.horizontalLayout_15.addWidget(self.le_frameExpression)
 
 
-        self.gridLayout_2.addWidget(self.f_taskname, 1, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_frameExpression)
 
-        self.w_context = QWidget(self.gb_NetRender)
-        self.w_context.setObjectName(u"w_context")
-        self.horizontalLayout_11 = QHBoxLayout(self.w_context)
-        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
-        self.horizontalLayout_11.setContentsMargins(9, 0, 9, 0)
-        self.label_7 = QLabel(self.w_context)
-        self.label_7.setObjectName(u"label_7")
+        self.f_cam = QWidget(self.gb_NetRender)
+        self.f_cam.setObjectName(u"f_cam")
+        self.horizontalLayout_2 = QHBoxLayout(self.f_cam)
+        self.horizontalLayout_2.setSpacing(0)
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setContentsMargins(9, 0, 9, 0)
 
-        self.horizontalLayout_11.addWidget(self.label_7)
+        self.verticalLayout_2.addWidget(self.f_cam)
 
-        self.horizontalSpacer_5 = QSpacerItem(37, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.w_renderPreset = QWidget(self.gb_NetRender)
+        self.w_renderPreset.setObjectName(u"w_renderPreset")
+        self.horizontalLayout_14 = QHBoxLayout(self.w_renderPreset)
+        self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
+        self.horizontalLayout_14.setContentsMargins(-1, 0, -1, 0)
+        self.l_renderPreset = QLabel(self.w_renderPreset)
+        self.l_renderPreset.setObjectName(u"l_renderPreset")
 
-        self.horizontalLayout_11.addItem(self.horizontalSpacer_5)
+        self.horizontalLayout_14.addWidget(self.l_renderPreset)
 
-        self.l_context = QLabel(self.w_context)
-        self.l_context.setObjectName(u"l_context")
+        self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.horizontalLayout_11.addWidget(self.l_context)
+        self.horizontalLayout_14.addItem(self.horizontalSpacer_7)
 
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.chb_renderPreset = QCheckBox(self.w_renderPreset)
+        self.chb_renderPreset.setObjectName(u"chb_renderPreset")
 
-        self.horizontalLayout_11.addItem(self.horizontalSpacer_3)
+        self.horizontalLayout_14.addWidget(self.chb_renderPreset)
 
-        self.b_context = QPushButton(self.w_context)
-        self.b_context.setObjectName(u"b_context")
+        self.cb_renderPreset = QComboBox(self.w_renderPreset)
+        self.cb_renderPreset.setObjectName(u"cb_renderPreset")
+        self.cb_renderPreset.setEnabled(False)
+        self.cb_renderPreset.setMinimumSize(QSize(150, 0))
 
-        self.horizontalLayout_11.addWidget(self.b_context)
-
-        self.cb_context = QComboBox(self.w_context)
-        self.cb_context.setObjectName(u"cb_context")
-
-        self.horizontalLayout_11.addWidget(self.cb_context)
+        self.horizontalLayout_14.addWidget(self.cb_renderPreset)
 
 
-        self.gridLayout_2.addWidget(self.w_context, 0, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.w_renderPreset)
+
+        self.w_master = QWidget(self.gb_NetRender)
+        self.w_master.setObjectName(u"w_master")
+        self.horizontalLayout_17 = QHBoxLayout(self.w_master)
+        self.horizontalLayout_17.setSpacing(0)
+        self.horizontalLayout_17.setObjectName(u"horizontalLayout_17")
+        self.horizontalLayout_17.setContentsMargins(9, 0, 9, 0)
+        self.l_outPath_2 = QLabel(self.w_master)
+        self.l_outPath_2.setObjectName(u"l_outPath_2")
+
+        self.horizontalLayout_17.addWidget(self.l_outPath_2)
+
+        self.horizontalSpacer_28 = QSpacerItem(113, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_17.addItem(self.horizontalSpacer_28)
+
+        self.cb_master = QComboBox(self.w_master)
+        self.cb_master.setObjectName(u"cb_master")
+        self.cb_master.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_17.addWidget(self.cb_master)
+
+
+        self.verticalLayout_2.addWidget(self.w_master)
+
+        self.w_outPath = QWidget(self.gb_NetRender)
+        self.w_outPath.setObjectName(u"w_outPath")
+        self.horizontalLayout_16 = QHBoxLayout(self.w_outPath)
+        self.horizontalLayout_16.setSpacing(0)
+        self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
+        self.horizontalLayout_16.setContentsMargins(9, 0, 9, 0)
+        self.l_outPath = QLabel(self.w_outPath)
+        self.l_outPath.setObjectName(u"l_outPath")
+
+        self.horizontalLayout_16.addWidget(self.l_outPath)
+
+        self.horizontalSpacer_27 = QSpacerItem(113, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_16.addItem(self.horizontalSpacer_27)
+
+        self.cb_outPath = QComboBox(self.w_outPath)
+        self.cb_outPath.setObjectName(u"cb_outPath")
+        self.cb_outPath.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_16.addWidget(self.cb_outPath)
+
+
+        self.verticalLayout_2.addWidget(self.w_outPath)
+
+        self.f_renderLayer = QWidget(self.gb_NetRender)
+        self.f_renderLayer.setObjectName(u"f_renderLayer")
+        self.horizontalLayout_5 = QHBoxLayout(self.f_renderLayer)
+        self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
+        self.horizontalLayout_5.setContentsMargins(9, 0, 9, 0)
+        self.label_5 = QLabel(self.f_renderLayer)
+        self.label_5.setObjectName(u"label_5")
+
+        self.horizontalLayout_5.addWidget(self.label_5)
+
+        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_5.addItem(self.horizontalSpacer_6)
+
+        self.cb_renderLayer = QComboBox(self.f_renderLayer)
+        self.cb_renderLayer.setObjectName(u"cb_renderLayer")
+        self.cb_renderLayer.setEnabled(True)
+        self.cb_renderLayer.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_5.addWidget(self.cb_renderLayer)
+
+
+        self.verticalLayout_2.addWidget(self.f_renderLayer)
+
+        self.w_format = QWidget(self.gb_NetRender)
+        self.w_format.setObjectName(u"w_format")
+        self.horizontalLayout_6 = QHBoxLayout(self.w_format)
+        self.horizontalLayout_6.setSpacing(0)
+        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
+        self.horizontalLayout_6.setContentsMargins(9, 0, 9, 0)
+        self.label_6 = QLabel(self.w_format)
+        self.label_6.setObjectName(u"label_6")
+
+        self.horizontalLayout_6.addWidget(self.label_6)
+
+        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_6.addItem(self.horizontalSpacer_12)
+
+        self.cb_format = QComboBox(self.w_format)
+        self.cb_format.setObjectName(u"cb_format")
+        self.cb_format.setMinimumSize(QSize(150, 0))
+
+        self.horizontalLayout_6.addWidget(self.cb_format)
+
+
+        self.verticalLayout_2.addWidget(self.w_format)
 
         self.f_updateVersion = QWidget(self.gb_NetRender)
         self.f_updateVersion.setObjectName(u"f_updateVersion")
@@ -363,7 +363,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_12.addWidget(self.label_9)
 
-        self.horizontalSpacer_10 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_10 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_12.addItem(self.horizontalSpacer_10)
 
@@ -373,7 +373,7 @@ class Ui_wg_NetRender(object):
         self.horizontalLayout_12.addWidget(self.chb_upVersion)
 
 
-        self.gridLayout_2.addWidget(self.f_updateVersion, 11, 0, 1, 1)
+        self.verticalLayout_2.addWidget(self.f_updateVersion)
 
 
         self.verticalLayout.addWidget(self.gb_NetRender)
@@ -395,7 +395,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_13.addWidget(self.l_manager)
 
-        self.horizontalSpacer_19 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_19 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_13.addItem(self.horizontalSpacer_19)
 
@@ -418,7 +418,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_21.addWidget(self.l_rjPrio)
 
-        self.horizontalSpacer_16 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_16 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_21.addItem(self.horizontalSpacer_16)
 
@@ -442,7 +442,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_22.addWidget(self.label_15)
 
-        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_22.addItem(self.horizontalSpacer_17)
 
@@ -466,7 +466,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_28.addWidget(self.l_rjTimeout)
 
-        self.horizontalSpacer_23 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_23 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_28.addItem(self.horizontalSpacer_23)
 
@@ -491,7 +491,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_26.addWidget(self.label_18)
 
-        self.horizontalSpacer_20 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_20 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_26.addItem(self.horizontalSpacer_20)
 
@@ -514,7 +514,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_27.addWidget(self.label_19)
 
-        self.horizontalSpacer_22 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_22 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_27.addItem(self.horizontalSpacer_22)
 
@@ -537,7 +537,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_23.addWidget(self.label_16)
 
-        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_23.addItem(self.horizontalSpacer_18)
 
@@ -560,7 +560,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_24.addWidget(self.label_17)
 
-        self.horizontalSpacer_21 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_21 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_24.addItem(self.horizontalSpacer_21)
 
@@ -603,7 +603,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_29.addWidget(self.l_dlConcurrentTasks)
 
-        self.horizontalSpacer_24 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_24 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_29.addItem(self.horizontalSpacer_24)
 
@@ -628,7 +628,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_30.addWidget(self.l_dlGPUpt)
 
-        self.horizontalSpacer_25 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_25 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_30.addItem(self.horizontalSpacer_25)
 
@@ -653,7 +653,7 @@ class Ui_wg_NetRender(object):
 
         self.horizontalLayout_31.addWidget(self.l_dlGPUdevices)
 
-        self.horizontalSpacer_26 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_26 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_31.addItem(self.horizontalSpacer_26)
 
@@ -681,7 +681,7 @@ class Ui_wg_NetRender(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollAreaWidgetContents = QWidget()
         self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
-        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 446, 144))
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 446, 95))
         self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.l_pathLast = QLabel(self.scrollAreaWidgetContents)
@@ -728,24 +728,24 @@ class Ui_wg_NetRender(object):
         self.l_name.setText(QCoreApplication.translate("wg_NetRender", u"Name:", None))
         self.l_class.setText(QCoreApplication.translate("wg_NetRender", u"NetworkRender", None))
         self.gb_NetRender.setTitle(QCoreApplication.translate("wg_NetRender", u"General", None))
-        self.l_renderPreset.setText(QCoreApplication.translate("wg_NetRender", u"Rendersettings preset:", None))
-        self.chb_renderPreset.setText("")
-        self.label_6.setText(QCoreApplication.translate("wg_NetRender", u"Format:", None))
-        self.l_outPath_2.setText(QCoreApplication.translate("wg_NetRender", u"Master Version:", None))
-        self.label_5.setText(QCoreApplication.translate("wg_NetRender", u"Render layer:", None))
-        self.l_outPath.setText(QCoreApplication.translate("wg_NetRender", u"Location:", None))
-        self.l_frameExpression.setText(QCoreApplication.translate("wg_NetRender", u"Frame expression:", None))
+        self.label_7.setText(QCoreApplication.translate("wg_NetRender", u"Context:", None))
+        self.l_context.setText("")
+        self.b_context.setText(QCoreApplication.translate("wg_NetRender", u"Select", None))
+        self.label_2.setText(QCoreApplication.translate("wg_NetRender", u"Identifier:", None))
+        self.l_taskName.setText("")
+        self.b_changeTask.setText(QCoreApplication.translate("wg_NetRender", u"change", None))
+        self.label_3.setText(QCoreApplication.translate("wg_NetRender", u"Framerange:", None))
         self.l_rangeEnd.setText(QCoreApplication.translate("wg_NetRender", u"1100", None))
         self.l_rangeStart.setText(QCoreApplication.translate("wg_NetRender", u"1001", None))
         self.l_rangeStartInfo.setText(QCoreApplication.translate("wg_NetRender", u"Start:", None))
         self.l_rangeEndInfo.setText(QCoreApplication.translate("wg_NetRender", u"End:", None))
-        self.label_3.setText(QCoreApplication.translate("wg_NetRender", u"Framerange:", None))
-        self.label_2.setText(QCoreApplication.translate("wg_NetRender", u"Identifier:", None))
-        self.l_taskName.setText("")
-        self.b_changeTask.setText(QCoreApplication.translate("wg_NetRender", u"change", None))
-        self.label_7.setText(QCoreApplication.translate("wg_NetRender", u"Context:", None))
-        self.l_context.setText("")
-        self.b_context.setText(QCoreApplication.translate("wg_NetRender", u"Select", None))
+        self.l_frameExpression.setText(QCoreApplication.translate("wg_NetRender", u"Frame expression:", None))
+        self.l_renderPreset.setText(QCoreApplication.translate("wg_NetRender", u"Rendersettings preset:", None))
+        self.chb_renderPreset.setText("")
+        self.l_outPath_2.setText(QCoreApplication.translate("wg_NetRender", u"Master Version:", None))
+        self.l_outPath.setText(QCoreApplication.translate("wg_NetRender", u"Location:", None))
+        self.label_5.setText(QCoreApplication.translate("wg_NetRender", u"Render layer:", None))
+        self.label_6.setText(QCoreApplication.translate("wg_NetRender", u"Format:", None))
 #if QT_CONFIG(tooltip)
         self.f_updateVersion.setToolTip(QCoreApplication.translate("wg_NetRender", u"If this checkbox is selected, executing the state won't render the node, instead it will set the correct name and version, it will also create the appropiate folders and set the path to it for easy access in the state's UI", None))
 #endif // QT_CONFIG(tooltip)


### PR DESCRIPTION
The custom state UI files were using a QGrid layout for the groupbox.  This was giving errors with some Prism plugin's that were expecting a QVBox layout.