### PR TITLE
138 wireless node names do not change with version change

### DIFF
--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_CompDb.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_CompDb.py
@@ -247,7 +247,7 @@ def savePrismFileDb(comp, cpData_orig:dict):
 
 #   Removes DB records if the node does not exist in Comp
 @err_catcher(name=__name__)
-def cleanPrismFileDb(comp, cpData_orig:dict) ->dict:
+def cleanPrismFileDb(comp, cpData_orig:dict) -> dict:
     try:
         cpData_cleaned = cpData_orig.copy()
 
@@ -536,7 +536,7 @@ def updateNodeInfo(comp, listType:str, UUID:str, nodeData:dict) -> bool:
 
 #   Return a list of MediaIds for a given type
 @err_catcher(name=__name__)
-def getMediaIDsForType(comp, listType:str) -> list:
+def getMediaIDsForType(comp, listType:str) -> list[str]:
     #   Get database data
     cpData = loadPrismFileDb(comp)
 
@@ -576,7 +576,7 @@ def getNodeInfo(comp, listType:str, UUID:str) -> dict:
 
 #   Returns list of import files based on selected tools
 @err_catcher(name=__name__)
-def getFilesFromSelTools(comp, importData:dict, selUIDs:list) -> list:
+def getFilesFromSelTools(comp, importData:dict, selUIDs:list) -> list[str]:
     selItems = []
     #   Get files list
     importFileList = importData["files"]
@@ -804,7 +804,7 @@ def getConnectedNodes(comp, listType:str, UUID:str) -> Union[list | None]:
 #	Gets either single UID or List of UID's
 #	and returns the original and all connected UUID's
 @err_catcher(name=__name__)
-def getAllConnectedNodes(comp, listType:str, nodeUIDs:Union[list|str]) -> list:
+def getAllConnectedNodes(comp, listType:str, nodeUIDs:Union[list|str]) -> list[Tool]:
     mainToolsUIDs = []
     allToolUIDs = []
 

--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
@@ -536,13 +536,16 @@ def getAllToolsByType(comp, type:str) -> list[Tool]:
         return None
     
 
-#   Returns tools selected in Comp
+#   Returns tools selected in Comp with optional Tool Type
 @err_catcher(name=__name__)
-def getSelectedTools(comp, type:str) -> list[Tool]:
+def getSelectedTools(comp, toolType:str=None) -> list[Tool]:
     try:
         toolList = []
         for tool in comp.GetToolList(True).values():
-            if getToolType(tool) == type:
+            if toolType:
+                if getToolType(tool) == type:
+                    toolList.append(tool)
+            else:
                 toolList.append(tool)
 
         return toolList

--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
@@ -926,7 +926,7 @@ def findLeftmostLowerNode(comp, threshold:int=0.5) -> Tool:
         return None
 
 
-@err_catcher(name=__name__)
+@err_catcher(name=__name__)                                                     #   TODO add this to the CompDB
 def sortingEnabled(comp, save:bool=False, checked:bool=None) -> bool:
     # Sets/Gets the checkbox state of the dialog as part of the comp data.
     if save:

--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
@@ -52,7 +52,7 @@
 
 import os
 import re
-from typing import Union, Dict, Any
+from typing import Union, Dict, Tuple, Any
 import logging
 
 from PrismUtils.Decorators import err_catcher as err_catcher
@@ -114,7 +114,7 @@ def saveScene(comp, filepath:str, details={}) -> bool:
     
 
 @err_catcher(name=__name__)
-def getFrameRange(comp) -> list[int, int]:
+def getFrameRange(comp) -> Tuple[int, int]:
     try:
         startframe = comp.GetAttrs()["COMPN_GlobalStart"]
         endframe = comp.GetAttrs()["COMPN_GlobalEnd"]
@@ -148,7 +148,7 @@ def setFrameRange(comp, startFrame:int, endFrame:int):
 
 
 @err_catcher(name=__name__)
-def getRenderRange(comp) -> list[int, int]:
+def getRenderRange(comp) -> Tuple[int, int]:
     try:
         startframe = comp.GetAttrs()["COMPN_RenderStart"]
         endframe = comp.GetAttrs()["COMPN_RenderEnd"]
@@ -176,7 +176,7 @@ def setRenderRange(comp, startFrame:int, endFrame:int):
 
 
 @err_catcher(name=__name__)
-def getFPS(comp) -> int:
+def getFPS(comp) -> float:
     try:
         return comp.GetPrefs()["Comp"]["FrameFormat"]["Rate"]
     except Exception as e:
@@ -186,7 +186,7 @@ def getFPS(comp) -> int:
 
 
 @err_catcher(name=__name__)
-def setFPS(comp, fps:int):
+def setFPS(comp, fps:float):
     try:
         return comp.SetPrefs({"Comp.FrameFormat.Rate": fps})
     except:
@@ -195,7 +195,7 @@ def setFPS(comp, fps:int):
 
 
 @err_catcher(name=__name__)
-def getResolution(comp) -> list[int, int]:
+def getResolution(comp) -> Tuple[int, int]:
     try:
         width = comp.GetPrefs()[
             "Comp"]["FrameFormat"]["Width"]
@@ -234,7 +234,7 @@ def getCurrentFrame(comp) -> int:
 
 #   Adds tool of specified type and configures given data
 @err_catcher(name=__name__)
-def addTool(comp, toolType:str, toolData:dict={}, xPos=-32768, yPos=-32768, autoConnect=1) -> Tool:
+def addTool(comp, toolType:str, toolData:dict={}, xPos:int=-32768, yPos:int=-32768, autoConnect=1) -> Tool:
     try:
         tool = comp.AddTool(toolType, xPos, yPos, autoConnect)
 
@@ -305,7 +305,7 @@ def addTool(comp, toolType:str, toolData:dict={}, xPos=-32768, yPos=-32768, auto
             tool.HoldLastFrame = 0
 
 
-        #   TODO    TRYING TO HAVE NODE SHOW NAME NOT CLIP PATH
+        #   TODO    TRYING TO HAVE TOOL SHOW NAME NOT CLIP PATH
         tool.SetAttrs({'TOOLS_NameSet': True})
 
         return tool
@@ -317,7 +317,7 @@ def addTool(comp, toolType:str, toolData:dict={}, xPos=-32768, yPos=-32768, auto
 
 #   Updates tool config for given data
 @err_catcher(name=__name__)
-def updateTool(tool:Tool, toolData:dict, xPos=-32768, yPos=-32768, autoConnect=1) -> Tool:
+def updateTool(tool:Tool, toolData:dict, xPos:int=-32768, yPos:int=-32768, autoConnect=1) -> Tool:
     try:
         if "toolName" in toolData:
             tool.SetAttrs({'TOOLS_Name' : toolData['toolName']})
@@ -351,7 +351,7 @@ def updateTool(tool:Tool, toolData:dict, xPos=-32768, yPos=-32768, autoConnect=1
             tool.HoldLastFrame = 0
 
 
-        #   TODO    TRYING TO HAVE NODE SHOW NAME NOT CLIP PATH
+        #   TODO    TRYING TO HAVE TOOL SHOW NAME NOT CLIP PATH
         tool.SetAttrs({'TOOLS_NameSet': True})
 
         return tool
@@ -386,9 +386,9 @@ def getToolData(tool:Tool) -> dict:
         return {}
     
 
-#   Creates a group with given tools.
+#   Creates a group with given tools and returns new UIDs.
 @err_catcher(name=__name__)
-def groupTools(comp, groupName:str, toolList:list, outputTool:Tool = None, inputTool:Tool = None) -> list:
+def groupTools(comp, groupName:str, toolList:list, outputTool:Tool = None, inputTool:Tool = None) -> list[UUID]:
     success = False
     toolUIDs = []
     toolsToCopy = dict()
@@ -513,21 +513,21 @@ def getToolByName(comp, toolName:str) -> Tool:
 
 #   Returns type of tool
 @err_catcher(name=__name__)
-def getNodeType(tool:Tool) -> str:
+def getToolType(tool:Tool) -> str:
     try:
         return tool.GetAttrs("TOOLS_RegID")
     except:
-        logger.warning("ERROR: Cannot retrieve node type")
+        logger.warning("ERROR: Cannot Retrieve Tool type")
         return None
 
 
 #   Returns all tools of specified type
 @err_catcher(name=__name__)
-def getAllToolsByType(comp, type:str) -> list:
+def getAllToolsByType(comp, type:str) -> list[Tool]:
     try:
         toolList = []
         for tool in comp.GetToolList(False).values():
-            if getNodeType(tool) == type:
+            if getToolType(tool) == type:
                 toolList.append(tool)
 
         return toolList
@@ -538,11 +538,11 @@ def getAllToolsByType(comp, type:str) -> list:
 
 #   Returns tools selected in Comp
 @err_catcher(name=__name__)
-def getSelectedTools(comp, type:str) -> list:
+def getSelectedTools(comp, type:str) -> list[Tool]:
     try:
         toolList = []
         for tool in comp.GetToolList(True).values():
-            if getNodeType(tool) == type:
+            if getToolType(tool) == type:
                 toolList.append(tool)
 
         return toolList
@@ -604,7 +604,7 @@ def hasConnectedInput(tool) -> bool:
 
 #   Connects two tools
 @err_catcher(name=__name__)
-def connectTools(toolFrom, toolTo) -> bool:
+def connectTools(toolFrom:Tool, toolTo:Tool) -> bool:
     try:
         #   Connect MainOutput to 1st MainInput (works for most situations)
         toolTo.FindMainInput(1).ConnectTo(toolFrom)
@@ -640,7 +640,7 @@ def getToolOutputSocket(tool) -> ToolOption:
 
 #   Returns list of input sockets that are connected to the tool's output
 @err_catcher(name=__name__)
-def getInputsFromOutput(tool) -> list:
+def getInputsFromOutput(tool) -> list[ToolOption]:
     try:
         #   Gets the Fusion table of inputs
         inputsDict = tool.FindMainOutput(1).GetConnectedInputs()
@@ -738,7 +738,7 @@ def makeWirelessName(importData:dict) -> str:
 #   The name of this function comes for its initial use to position
 #   the "state manager node" that what used before using SetData.
 @err_catcher(name=__name__)
-def setNodePosition(comp, node, find_min=True, x_offset=-2, y_offset=0, ignore_node_type:str=None, refNode:Tool=None):
+def setToolPosition(comp, node, find_min=True, x_offset=-2, y_offset=0, ignore_node_type:str=None, refNode:Tool=None):
     # Get the active composition
     flow = comp.CurrentFrame.FlowView
 
@@ -758,43 +758,112 @@ def setNodePosition(comp, node, find_min=True, x_offset=-2, y_offset=0, ignore_n
     # if xmost_node:
     if refNode:
         thresh_x_position, thresh_y_position = postable = flow.GetPosTable(refNode).values()
-        set_node_position(flow, node, thresh_x_position + x_offset, thresh_y_position + y_offset)
+        setToolPosition(flow, node, thresh_x_position + x_offset, thresh_y_position + y_offset)
     else:
         flow.Select()
         x,y = find_LastClickPosition(comp)
         flow.SetPos(node, x, y)
 
 
-
+#   Returns Position of Tool
 @err_catcher(name=__name__)
-def setNodeToLeft(comp, tool, refNode=None, x_offset:int=0, y_offset:int=1):
-    if refNode:
-        if getNodeType(refNode) == "Loader":
-            setNodePosition(comp, tool, x_offset = 0, y_offset = 1, refNode=refNode)
-        else:
-            setNodePosition(comp, tool, x_offset = -5, y_offset = 0, refNode=refNode)
-    else:
-        setNodePosition(comp, tool, x_offset = 0, y_offset = 0, refNode=refNode)
-
-
-@err_catcher(name=__name__)
-def set_node_position(flow, smnode:Tool, x:int, y:int):
-    flow.SetPos(smnode, x, y)
-
-
-@err_catcher(name=__name__)
-def matchNodePos(comp, nodeTomove:Tool, nodeInPos:Tool):
+def getToolPosition(comp, tool:Tool) -> Tuple[float, float]:
     flow = comp.CurrentFrame.FlowView
-    x,y = flow.GetPosTable(nodeInPos).values()
-    set_node_position(flow, nodeTomove, x, y)
+    try:
+        return list(flow.GetPosTable(tool).values())
+    except:
+        logger.warning(f"ERROR: Unable to get position of {tool}.")
+        return 0, 0
+
+
+#   Set Tool Position in Comp
+@err_catcher(name=__name__)
+def setToolPosition(flow, tool:Tool, x:float, y:float):
+    try:
+        flow.SetPos(tool, x, y)
+    except:
+        logger.warning(f"ERROR: Unable to set position of {tool}")
+
+
+#   Sets Tool Position Relative to Another Tool
+@err_catcher(name=__name__)
+def setToolPosRelative(comp, tool, refTool, x_offset:float=1, y_offset:float=0):
+    try:
+        flow = comp.CurrentFrame.FlowView
+
+        #   Get Position of Ref Tool
+        x, y = getToolPosition(comp, refTool)
+
+        #   Set Tool Position with Offset
+        setToolPosition(flow, tool, x + x_offset, y + y_offset)
+    except:
+        logger.warning(f"ERROR: Unable to set {tool} position relative to {refTool}")
+
+
+#   Set Tool Position Depending on Type
+@err_catcher(name=__name__)
+def setToolToLeft(comp, tool, refNode=None, x_offset:float=0, y_offset:float=1):
+    try:
+        if refNode:
+            #   Checks if it is a Loader from Prism
+            if getToolType(refNode) == "Loader" and getToolData(refNode) != {}:
+                #   Set Under other Loaders
+                setToolPosRelative(comp, tool, refNode, x_offset = 0, y_offset = 1)
+            else:
+                #   Set to the Left of Flow
+                setToolPosRelative(comp, tool, refNode, x_offset = -8, y_offset = 0)
+        else:
+            #   Just put in position
+            setToolPosition(comp, tool, x_offset = 0, y_offset = 0)
+    except:
+        logger.warning(f"ERROR: Unable to set {tool} to the left")
+
+
+#   Checks if Tool is within a Threshold Distance of Another Tool OR Position
+@err_catcher(name=__name__)
+def isToolNearTool(comp, tool, refTool:Tool=None, refPos:Tuple[float, float]=None, thresh:float=3) -> bool:
+    flow = comp.CurrentFrame.FlowView
+
+    try:
+        #   If given a ref Tool, get its position
+        if refTool:
+            refPos = getToolPosition(comp, refTool)
+
+        #   Make sure the position is a dict for Fusion
+        if not isinstance(refPos, list):
+            logger.warning("ERROR: Unable to check tool proximity, incorrect reference position.")
+            return True
+        
+        #   Get position of Tool
+        toolPos = getToolPosition(comp, tool)
+
+        #   Calculate distances
+        distX = abs(toolPos[0] - refPos[0])
+        distY = abs(toolPos[1] - refPos[1])
+
+        #   If both X and Y are within Threshold
+        if distX <= thresh and distY <= thresh:
+            return True
+        else:
+            return False
+    except:
+        logger.warning("ERROR: Unable to check tool proximity.")
+        return True
+
+
+@err_catcher(name=__name__)
+def matchToolPos(comp, nodeTomove:Tool, nodeInPos:Tool):
+    flow = comp.CurrentFrame.FlowView
+    x,y = getToolPosition(comp, nodeInPos)
+    setToolPosition(flow, nodeTomove, x, y)
 
 
 #Get last click on comp view.
 @err_catcher(name=__name__)
-def find_LastClickPosition(comp) -> list[int, int]:
+def find_LastClickPosition(comp) -> Tuple[int, int]:
     flow = comp.CurrentFrame.FlowView
     posNode = comp.AddToolAction("Background")
-    x,y = flow.GetPosTable(posNode).values()
+    x,y = getToolPosition(comp, posNode)
     posNode.Delete()
 
     return x,y
@@ -802,7 +871,7 @@ def find_LastClickPosition(comp) -> list[int, int]:
 
 
 @err_catcher(name=__name__)
-def posRelativeToNode(comp, node, xoffset=3) -> bool:
+def posRelativeToTool(comp, tool, xoffset:float=3) -> bool:
     flow = comp.CurrentFrame.FlowView
     #check if there is selection
     if len(comp.GetToolList(True).values()) > 0:
@@ -810,13 +879,13 @@ def posRelativeToNode(comp, node, xoffset=3) -> bool:
             activeNode = comp.ActiveTool()
         except:
             activeNode = comp.GetToolList(True)[1]
-        if not activeNode.Name == node.Name:
+        if not activeNode.Name == tool.Name:
             postable = flow.GetPosTable(activeNode)
             if postable:
                 x, y = postable.values()
-                flow.SetPos(node, x + xoffset, y)
+                flow.SetPos(tool, x + xoffset, y)
                 try:
-                    node.ConnectInput('Input', activeNode)
+                    tool.ConnectInput('Input', activeNode)
                 except:
                     pass
                 return True
@@ -826,7 +895,7 @@ def posRelativeToNode(comp, node, xoffset=3) -> bool:
 
 # Arranges nodes in a vertical stack
 @err_catcher(name=__name__)
-def stackNodesByList(comp, toolList: list, xoffset=0, yoffset=1):
+def stackToolsByList(comp, toolList: list[Tool], xoffset:float=0, yoffset:float=1):
     flow = comp.CurrentFrame.FlowView
 
     # Ensure there is at least one tool to stack
@@ -866,11 +935,9 @@ def stackNodesByList(comp, toolList: list, xoffset=0, yoffset=1):
     return avgX, avgY
 
 
-
-
 #	Arranges nodes in a vertcal stack
 @err_catcher(name=__name__)
-def stackNodesByType(comp, nodetostack:Tool, yoffset=3, tooltype:str="Saver"):
+def stackToolsByType(comp, nodetostack:Tool, yoffset:float=3, tooltype:str="Saver"):
     flow = comp.CurrentFrame.FlowView
 
     origx, origy = flow.GetPosTable(nodetostack).values()
@@ -906,7 +973,7 @@ def stackNodesByType(comp, nodetostack:Tool, yoffset=3, tooltype:str="Saver"):
 
 
 @err_catcher(name=__name__)
-def findLeftmostLowerNode(comp, threshold:int=0.5) -> Tool:
+def findLeftmostLowerTool(comp, threshold:float=0.5) -> Tool:
     flow = comp.CurrentFrame.FlowView
 
     try:
@@ -927,7 +994,7 @@ def findLeftmostLowerNode(comp, threshold:int=0.5) -> Tool:
 
 
 @err_catcher(name=__name__)
-def getLoaderChannels(tool) -> list:
+def getLoaderChannels(tool) -> list[str]:
     # Get all loader channels and filter out the ones to skip
     skip = {			
         "SomethingThatWontMatchHopefully".lower(),
@@ -976,15 +1043,4 @@ def getChannelData(loaderChannels:list) -> dict:
         logger.warning("ERROR: Failed to get channel data")
         return None
     
-
-
-# @err_catcher(name=__name__)                                           #   NEEDED ?
-# def splitLoaderName(name:str) -> list:
-#     try:
-#         prefix = name.rsplit('_', 1)[0]  # everything to the left of the last "_"
-#         suffix = name.rsplit('_', 1)[-1]  # everything to the right of the last "_"
-#         return prefix, suffix
-    
-#     except:
-#         logger.warning(f"ERROR: Unable to split loader name {name}")
 

--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_Fus.py
@@ -926,24 +926,6 @@ def findLeftmostLowerNode(comp, threshold:int=0.5) -> Tool:
         return None
 
 
-@err_catcher(name=__name__)                                                     #   TODO add this to the CompDB
-def sortingEnabled(comp, save:bool=False, checked:bool=None) -> bool:
-    # Sets/Gets the checkbox state of the dialog as part of the comp data.
-    if save:
-        try:
-            comp.SetData("isPrismImportChbxCheck", checked)
-            return True
-        except:
-            logger.warning("ERROR:  Unable to save Sorting Checkbox state")
-            return False
-
-    try:
-        return bool(comp.GetData("isPrismImportChbxCheck", default=False))
-    except:
-        logger.warning("ERROR:  Unable to get Sorting Checkbox state")
-        return False
-    
-
 @err_catcher(name=__name__)
 def getLoaderChannels(tool) -> list:
     # Get all loader channels and filter out the ones to skip

--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_Helper.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_Helper.py
@@ -119,27 +119,6 @@ def getFusLegalName(origName:str, check:bool=False) -> str:			#	TODO  Restructur
     return newName
 
 
-#	Sets up the name based on avail data
-@err_catcher(name=__name__)
-def makeLdrName(importData:dict) -> str:
-    try:
-        ldrName = importData.get('identifier') or importData.get("mediaId")
-
-        if "aov" in importData:
-            ldrName = ldrName + f"_{importData['aov']}"
-
-        if "channel" in importData:
-            ldrName = ldrName + f"_{importData['channel']}"
-   
-        ldrName = ldrName + f"_{importData['version']}"
-        
-        return ldrName
-    
-    except Exception as e:
-        logger.warning(f"ERROR: Unable to make Loader name from Import Data:\n{e}")
-        return None
-
-
 #   Makes import data dict from various Prism data sources
 @err_catcher(name=__name__)
 def makeImportData(plugin, context:dict, aovDict:dict, sourceData:dict) -> dict:

--- a/Fusion/Scripts/Libs/Prism_Fusion_lib_Helper.py
+++ b/Fusion/Scripts/Libs/Prism_Fusion_lib_Helper.py
@@ -296,7 +296,7 @@ def getFileDataFromAOV(fileList:list, aov:str) -> dict:
 
 #	Returns an average luminance value
 @err_catcher(name=__name__)
-def calculateLuminance(color:dict) -> int:
+def calculateLuminance(color:dict) -> float:
     try:
         r,g,b = color['R'], color['G'], color['B']
         # No need for normalization if RGB values are already in [0, 1]

--- a/Fusion/Scripts/Prism_Fusion_Functions.py
+++ b/Fusion/Scripts/Prism_Fusion_Functions.py
@@ -1087,7 +1087,7 @@ class Prism_Fusion_Functions(object):
 			return
 
 		#	Get "Sorting" checkbox state	
-		sorting = Fus.sortingEnabled(comp)
+		sorting = CompDb.sortingEnabled(comp)
 
 		# Setup Dialog
 		fString = "Please select an import option:"	
@@ -1114,7 +1114,7 @@ class Prism_Fusion_Functions(object):
 
 		#	Save "Sorting" checkbox state
 		if checkbox_checked is not None:
-			Fus.sortingEnabled(comp, save=True, checked=checkbox_checked)
+			CompDb.sortingEnabled(comp, save=True, checked=checkbox_checked)
 
 		#	Call the import with options and passing the data
 		if importType in ["Import Media", "Current AOV", "All AOVs"]:
@@ -3471,10 +3471,11 @@ path = r\"%s\"
 				except:
 					logger.debug(f"Unable to remove default state: {state}")
 
-		comp = self.getCurrentComp()
-		
+
 		#Set the comp used when sm was opened for reference when saving states.
+		comp = self.getCurrentComp()
 		self.comp = comp
+
 		#Set State Manager Data on first open.
 		if CompDb.sm_readStates(comp) is None:
 			self.setDefaultState()

--- a/Fusion/Scripts/Prism_Fusion_Functions.py
+++ b/Fusion/Scripts/Prism_Fusion_Functions.py
@@ -208,6 +208,7 @@ class Prism_Fusion_Functions(object):
 			'Chocolate': {'R': 0.5490196078431373, 'G': 0.35294117647058826, 'B': 0.24705882352941178}
 		}
 
+
 	@err_catcher(name=__name__)
 	def startup(self, origin):
 		# 	for obj in QApplication.topLevelWidgets():
@@ -766,6 +767,9 @@ class Prism_Fusion_Functions(object):
 			comp = self.getCurrentComp()
 		if self.sm_checkCorrectComp(comp):
 			if not CompDb.nodeExists(comp, nodeUID):
+				#	Get selected Tool
+
+				selTools = Fus.getSelectedTools(comp)
 
 				#	Add Saver to Comp
 				sv = Fus.addTool(comp, "Saver", nodeData)
@@ -774,11 +778,11 @@ class Prism_Fusion_Functions(object):
 				CompDb.addNodeToDB(comp, "render2d", nodeUID, nodeData)
 
 				#	Position Saver
-				if not Fus.posRelativeToTool(comp, sv):
+				if selTools:
 					try:
-						#Move Render Node to the Right of the scene	
-						Fus.setToolPosition(comp, sv, find_min=False, x_offset=10, ignore_node_type="Saver")
-						Fus.stackToolsByType(comp, sv)
+						#	Move Render Node to the Right of the scene	
+						Fus.setToolPosRelative(comp, sv, selTools[0], 3)
+						# Fus.stackToolsByType(comp, sv)
 					except:
 						logger.debug(f"ERROR: Not able to position {nodeData['nodeName']}")
 

--- a/Fusion/Scripts/Prism_Fusion_Functions.py
+++ b/Fusion/Scripts/Prism_Fusion_Functions.py
@@ -1534,6 +1534,9 @@ class Prism_Fusion_Functions(object):
 					Fus.updateTool(ldr, toolData)
 					#	Update Database record
 					CompDb.updateNodeInfo(comp, "import2d", uid, toolData)
+
+					#	Update Wireless name
+					self.updateWireless(comp, uid)
 					
 			except Exception as e:
 				logger.warning(f"ERROR: Unable to update {importData['identifier']}")
@@ -1550,6 +1553,8 @@ class Prism_Fusion_Functions(object):
 		self.updateMsgPopup(formattedMsg)
 
 
+	#	Creates and adds a Wireless set to the Loader
+	#	This uses an AutoDomain tool for the "IN", and the Wireless for the "OUT"
 	@err_catcher(name=__name__)
 	def createWireless(self, nodeUID):							#	TODO  Look into adding wireless with "addTool"
 		wirelessCopy = """{
@@ -1576,7 +1581,6 @@ class Prism_Fusion_Functions(object):
 		comp = self.getCurrentComp()
 		flow = comp.CurrentFrame.FlowView
 		tool = CompDb.getNodeByUID(comp, nodeUID)
-
 		
 		try:
 			pyperclip.copy(wirelessCopy)
@@ -1615,6 +1619,31 @@ class Prism_Fusion_Functions(object):
 
 		except Exception as e:
 			logger.warning(f"ERROR:  Could not add wireless nodes:\n{e}")
+
+
+	#	Updates Wireless Name
+	@err_catcher(name=__name__)
+	def updateWireless(self, comp, uid):
+
+		ldrData = CompDb.getNodeInfo(comp, "import2d", uid)
+
+		self.core.popup(f"ldrData: {ldrData}")                                      #    TESTING
+
+		connectedNodes = ldrData.get("connectedNodes", None)
+
+		if connectedNodes:
+			for nodeUID in connectedNodes:
+
+				self.core.popup(f"nodeUID: {nodeUID}")                                      #    TESTING
+
+				tool = CompDb.getNodeByUID(comp, nodeUID)
+
+				self.core.popup(f"tool: {tool}")                                      #    TESTING
+
+				toolName = tool.Name
+
+				self.core.popup(f"toolName: {toolName}")                                      #    TESTING
+
 
 
 

--- a/Fusion/Scripts/StateManagerNodes/fus_Object3d_Import.py
+++ b/Fusion/Scripts/StateManagerNodes/fus_Object3d_Import.py
@@ -166,17 +166,22 @@ class Object3d_ImportClass(object):
         self.l_class.setText(stateMode)
 
 
-    @err_catcher(name=__name__)                                     #   TODO  Fix parenting to bring to front
+    @err_catcher(name=__name__)
     def requestImportPaths(self):
-        result = self.core.callback("requestImportPath", self)
+        #   Calls the Prism Library window as per Prism settings
+        result = self.core.callback("requestImportPath", self.stateManager)
+
+        #   If user selects from Library, returns file path
         for res in result:
             if isinstance(res, dict) and res.get("importPaths") is not None:
                 return res["importPaths"]
 
+        #   Calls Product Browser
         import ProductBrowser
         ts = ProductBrowser.ProductBrowser(core=self.core, importState=self)
         self.core.parentWindow(ts)
         ts.exec_()
+        #   If user selects from Library, returns file path
         importPath = [ts.productPath]
         return importPath
 

--- a/Fusion/Scripts/StateManagerNodes/fus_Object3d_Import.py
+++ b/Fusion/Scripts/StateManagerNodes/fus_Object3d_Import.py
@@ -168,13 +168,19 @@ class Object3d_ImportClass(object):
 
     @err_catcher(name=__name__)
     def requestImportPaths(self):
-        #   Calls the Prism Library window as per Prism settings
-        result = self.core.callback("requestImportPath", self.stateManager)
+        #   Calls the Prism Library window as per Prism settings from callback in Librries plugin
 
-        #   If user selects from Library, returns file path
-        for res in result:
-            if isinstance(res, dict) and res.get("importPaths") is not None:
-                return res["importPaths"]
+        # DISABLED - So will always open ProjectBrowser->Products tab
+        #   vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+        # # result = self.core.callback("requestImportPath", self.stateManager)     #   TODO This causes issue on one machine when opening SM after import
+        # result = self.core.callback("requestImportPath", self)     #   TODO This works but window behind SM.
+
+        # #   If user selects from Library, returns file path
+        # for res in result:
+        #     if isinstance(res, dict) and res.get("importPaths") is not None:
+        #         return res["importPaths"]
+
+        #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
         #   Calls Product Browser
         import ProductBrowser

--- a/Fusion/Scripts/StateManagerNodes/fus_USD_Import.py
+++ b/Fusion/Scripts/StateManagerNodes/fus_USD_Import.py
@@ -169,15 +169,20 @@ class USD_ImportClass(object):
 
     @err_catcher(name=__name__)
     def requestImportPaths(self):
-        result = self.core.callback("requestImportPath", self)
+        #   Calls the Prism Library window as per Prism settings
+        result = self.core.callback("requestImportPath", self.stateManager)
+
+        #   If user selects from Library, returns file path
         for res in result:
             if isinstance(res, dict) and res.get("importPaths") is not None:
                 return res["importPaths"]
 
+        #   Calls Product Browser
         import ProductBrowser
         ts = ProductBrowser.ProductBrowser(core=self.core, importState=self)
         self.core.parentWindow(ts)
         ts.exec_()
+        #   If user selects from Library, returns file path
         importPath = [ts.productPath]
         return importPath
 

--- a/Fusion/Scripts/StateManagerNodes/fus_USD_Import.py
+++ b/Fusion/Scripts/StateManagerNodes/fus_USD_Import.py
@@ -169,13 +169,19 @@ class USD_ImportClass(object):
 
     @err_catcher(name=__name__)
     def requestImportPaths(self):
-        #   Calls the Prism Library window as per Prism settings
-        result = self.core.callback("requestImportPath", self.stateManager)
+        #   Calls the Prism Library window as per Prism settings from callback in Librries plugin
 
-        #   If user selects from Library, returns file path
-        for res in result:
-            if isinstance(res, dict) and res.get("importPaths") is not None:
-                return res["importPaths"]
+        # DISABLED - So will always open ProjectBrowser->Products tab
+        #   vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+        # # result = self.core.callback("requestImportPath", self.stateManager)     #   TODO This causes issue on one machine when opening SM after import
+        # result = self.core.callback("requestImportPath", self)     #   TODO This works but window behind SM.
+
+        # #   If user selects from Library, returns file path
+        # for res in result:
+        #     if isinstance(res, dict) and res.get("importPaths") is not None:
+        #         return res["importPaths"]
+
+        #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
         #   Calls Product Browser
         import ProductBrowser


### PR DESCRIPTION
Merged branch 138:

- Moved sortLoaders back to main code to be able to use libraries more.
- Changed "type" arg to "listType" to avoid confusion
- Modified CompDb "connectedNodes" to use a dict with names
- Moved Sorting Checkbox-disabled state to CompDB
- Added ability for moved Wireless_OUT to stay in position.
- Added ability for a tool in between Loader and Wireless_IN to stay in position.
- Removed some redundant sorting calls
- Added some Fus Lib functions.
- While in there, cleaned some type hints.
- Changed some names "Node" to "Tool"

Added ability to skip Wireless_OUT reposition [#138](https://github.com/Animatect/Prism2_PluginFusion/issues/138)
This checks if the Wireless_OUT has been moved away from the Loader stack by the user.  This allows the user to reposition the Wireless into the comp flow if desired and not have its position affected by other re-sorts.

This checks the distance of the _OUT to the _IN, and if below the threshold it will reposition.


The original fix passed self.statemanger to the callback in the Libraries plugin.  But found on one machine there is an issue that I think comes from the order of plugin's loading.

What I saw was that if a user opens the SM and imports a 3d item, then closes the SM when they reopen the SM it does not load correctly.

This fix just disables the callback functions to the Libraries plugin until more investigation.  This means when importing 3d it will always open the ProjectBrowser which is not a big deal.